### PR TITLE
Disable indexing headings in dev

### DIFF
--- a/.changeset/unlucky-ducks-greet.md
+++ b/.changeset/unlucky-ducks-greet.md
@@ -1,0 +1,6 @@
+---
+'@showroomjs/core': minor
+'react-showroom': minor
+---
+
+Disable indexing heading in development to reduce recompilation overhead

--- a/docs/docs/configuration.mdx
+++ b/docs/docs/configuration.mdx
@@ -319,6 +319,15 @@ Path to a module/file that export default a React component as placeholder when 
 
 The component will receives `componentFilePath` prop (`string`).
 
+### `search.includeHeadings`
+
+- Type: `boolean`
+- Default: `true` for `build`, `false` for `dev`
+
+Whether the search results should include headings of markdowns.
+
+By default we disable this for `dev` command to reduce recompilation overhead, but you can force it to be always `true`.
+
 ### `theme.audienceToggle`
 
 - Type: `'design' | 'code' | false`

--- a/docs/react-showroom.config.js
+++ b/docs/react-showroom.config.js
@@ -165,4 +165,7 @@ module.exports = defineConfig({
     port: 8989,
   },
   assetDir: 'assets',
+  search: {
+    includeHeadings: true,
+  },
 });

--- a/packages/core/src/react.ts
+++ b/packages/core/src/react.ts
@@ -209,6 +209,10 @@ export interface ShowroomHtmlConfiguration {
   preview?: HtmlOptions;
 }
 
+export interface ShowroomSearchConfiguration {
+  includeHeadings: boolean;
+}
+
 export interface ReactShowroomConfiguration {
   /**
    * URL for the site.
@@ -308,6 +312,7 @@ export interface ReactShowroomConfiguration {
      */
     basePath?: string;
   };
+  search?: Partial<ShowroomSearchConfiguration>;
   /**
    * Set cache directory for the build.
    *
@@ -395,6 +400,7 @@ export interface NormalizedReactShowroomConfiguration
   };
   html: ShowroomHtmlConfiguration;
   example: ExampleConfiguration;
+  search: ShowroomSearchConfiguration;
   /**
    * typescript compiler options to be used in advanced code editor
    */
@@ -503,7 +509,7 @@ export interface SearchIndexMarkdownItem {
   slug: string;
   frontmatter: ReactShowroomMarkdownFrontmatter;
   fallbackTitle: string;
-  headings: Array<SearchIndexHeading>;
+  headings?: Array<SearchIndexHeading>;
   formatLabel: (oriTitle: string) => string;
 }
 

--- a/packages/react-showroom/client/lib/search-options.ts
+++ b/packages/react-showroom/client/lib/search-options.ts
@@ -42,16 +42,18 @@ function collectOptions(indexItems: SearchIndexItem[]) {
               description: item.frontmatter.description,
               icon: 'markdown',
             });
-            item.headings.forEach((heading) => {
-              if (heading.slug) {
-                headingOptions.push({
-                  label: heading.text,
-                  value: `/${item.slug}#${heading.slug}`,
-                  description: title,
-                  icon: 'section',
-                });
-              }
-            });
+            if (item.headings) {
+              item.headings.forEach((heading) => {
+                if (heading.slug) {
+                  headingOptions.push({
+                    label: heading.text,
+                    value: `/${item.slug}#${heading.slug}`,
+                    description: title,
+                    icon: 'section',
+                  });
+                }
+              });
+            }
           }
           break;
 

--- a/packages/react-showroom/src/config/create-webpack-config.ts
+++ b/packages/react-showroom/src/config/create-webpack-config.ts
@@ -20,7 +20,7 @@ import {
   generateWrapper,
   generateAllComponentsPaths,
   generateDocPlaceHolder,
-  generateIndex,
+  generateSearchIndex,
 } from '../lib/generate-showroom-data';
 import { logToStdout } from '../lib/log-to-stdout';
 import { mergeWebpackConfig } from '../lib/merge-webpack-config';
@@ -232,6 +232,7 @@ const createBaseWebpackConfig = (
     cacheDir,
     example: exampleConfig,
     componentsEntry,
+    search,
     compilerOptions,
   } = config;
 
@@ -274,7 +275,7 @@ const createBaseWebpackConfig = (
     [resolveShowroom('node_modules/react-showroom-doc-placeholder.js')]:
       generateDocPlaceHolder(exampleConfig.placeholder),
     [resolveShowroom('node_modules/react-showroom-index.js')]:
-      generateIndex(sections),
+      generateSearchIndex(sections, search.includeHeadings),
   });
 
   const babelPreset = createBabelPreset(mode);

--- a/packages/react-showroom/src/lib/get-config.ts
+++ b/packages/react-showroom/src/lib/get-config.ts
@@ -129,6 +129,9 @@ export const getConfig = (
       },
     } = {},
     html = {},
+    search: {
+      includeHeadings: searchIncludeHeadings = env === 'production',
+    } = {},
     ...providedConfig
   } = userConfig || getUserConfig(env, configFile);
 
@@ -221,6 +224,9 @@ export const getConfig = (
       ...providedThemeConfig,
     },
     imports: componentsEntry ? imports.concat(componentsEntry) : imports,
+    search: {
+      includeHeadings: searchIncludeHeadings,
+    },
     compilerOptions: (config && config.compilerOptions) || {},
   };
 


### PR DESCRIPTION
Indexing the heading causing dev server recompilation slow.

Disable for dev by default, but expose config options if someone really want to always have it.