### PR TITLE
fix usePropsEditor not working in doc

### DIFF
--- a/.changeset/fresh-lobsters-live.md
+++ b/.changeset/fresh-lobsters-live.md
@@ -1,0 +1,5 @@
+---
+'react-showroom': patch
+---
+
+Fix usePropsEditor not working in doc

--- a/examples/react-example/docs/about.md
+++ b/examples/react-example/docs/about.md
@@ -43,6 +43,42 @@ import cx from 'classnames';
 console.log(cx('hahaha', true && 'lol'));
 ```
 
+[Component playground](https://react-showroom.js.org/getting-started/component-playground) example:
+
+```tsx live frame
+import { usePropsEditor } from 'react-showroom/client';
+import { Button } from 'components';
+
+const Demo = () => {
+  const editor = usePropsEditor({
+    initialProps: {
+      children: 'Bye',
+      variant: 'outline',
+    },
+    controls: {
+      children: 'text',
+      variant: {
+        type: 'select',
+        options: [
+          {
+            label: 'primary',
+            value: 'primary',
+          },
+          {
+            label: 'outline',
+            value: 'outline',
+          },
+        ],
+      },
+    },
+  });
+
+  return <Button {...editor.props} />;
+};
+
+<Demo />;
+```
+
 ## Autolink literals
 
 www.example.com, https://example.com, and contact@example.com.


### PR DESCRIPTION
This PR fix usage of `usePropsEditor` in doc (markdown without associated component) by fallback gracefully when `componentMeta` is not available.